### PR TITLE
Change BraveVPNDisabled and BraveAIChatEnabled from integer to boolean values

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-04T15:50:02Z</date>
+	<date>2024-12-11T16:26:57Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -10249,53 +10249,33 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>0</integer>
+			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave VPN Enabled; true = Brave VPN Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveVPNDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>0</integer>
-				<integer>1</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Enable</string>
-				<string>Disable</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave VPN</string>
 			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_type_input</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>1</integer>
+			<true/>
+			<key>pfm_description</key>
+			<string>false = Brave AI Chat Disabled; true = Brave Ai Chat Enabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveAIChatEnabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>0</integer>
-				<integer>1</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Disable</string>
-				<string>Enable</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Enable Brave AI Chat</string>
 			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_type_input</key>
 			<string>boolean</string>
 			<key>pfmx_comment</key>
-			<string>`1` is the default value, see https://github.com/brave/brave-browser/issues/36974</string>
+			<string>`enabled` is the default value, see https://github.com/brave/brave-browser/issues/36974</string>
 		</dict>
 		<dict>
 			<key>pfm_description</key>
@@ -10382,6 +10362,6 @@ If the policy DeveloperToolsAvailability is set, the value of the policy Develop
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>17</integer>
+	<integer>16</integer>
 </dict>
 </plist>

--- a/Resources/ChromeToBrave/com.brave.Browser-specific.plist
+++ b/Resources/ChromeToBrave/com.brave.Browser-specific.plist
@@ -108,53 +108,33 @@
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>0</integer>
+			<false/>
+			<key>pfm_description</key>
+			<string>false = Brave VPN Enabled; true = Brave VPN Disabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveVPNDisabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>0</integer>
-				<integer>1</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Enable</string>
-				<string>Disable</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Disable Brave VPN</string>
 			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_type_input</key>
 			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<integer>1</integer>
+			<true/>
+			<key>pfm_description</key>
+			<string>false = Brave AI Chat Disabled; true = Brave Ai Chat Enabled</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy</string>
 			<key>pfm_name</key>
 			<string>BraveAIChatEnabled</string>
-			<key>pfm_range_list</key>
-			<array>
-				<integer>0</integer>
-				<integer>1</integer>
-			</array>
-			<key>pfm_range_list_titles</key>
-			<array>
-				<string>Disable</string>
-				<string>Enable</string>
-			</array>
 			<key>pfm_title</key>
 			<string>Enable Brave AI Chat</string>
 			<key>pfm_type</key>
-			<string>integer</string>
-			<key>pfm_type_input</key>
 			<string>boolean</string>
 			<key>pfmx_comment</key>
-			<string>`1` is the default value, see https://github.com/brave/brave-browser/issues/36974</string>
+			<string>`enabled` is the default value, see https://github.com/brave/brave-browser/issues/36974</string>
 		</dict>
 	</array>
 	<key>Updates</key>


### PR DESCRIPTION
Change `BraveVPNDisabled` and `BraveAIChatEnabled` from integer to boolean values.

When using an integer, Brave doesn't successfully apply the policy and shows an error at `brave://policy`

This does go against their documentation at [https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy](https://support.brave.com/hc/en-us/articles/360039248271-Group-Policy)