### PR TITLE
Update 1Password 8 Manifest

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-02-01T10:06:10Z</date>
+	<date>2024-12-19T22:03:37Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -111,6 +111,8 @@
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
+				<string>Browser</string>
+				<string>General</string>
 				<string>Privacy</string>
 				<string>Security</string>
 				<string>Updates</string>
@@ -119,21 +121,36 @@
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
+				<key>Browser</key>
+				<array>
+					<string>browsers.other-trusted-apps.enabled</string>
+				</array>
+				<key>General</key>
+				<array>
+					<string>app.startAtLogin</string>
+					<string>security.autofill.autosubmit</string>
+				</array>
 				<key>Privacy</key>
 				<array>
-					<string>privacy.downloadRichIcons</string>
+					<string>privacy.checkCompromisedWebsites</string>
 					<string>privacy.checkHibp</string>
+					<string>privacy.checkMfa</string>
+					<string>privacy.checkPasskeys</string>
+					<string>privacy.downloadRichIcons</string>
 				</array>
 				<key>Security</key>
 				<array>
 					<string>security.authenticatedUnlock.appleTouchId</string>
 					<string>security.authenticatedUnlock.appleWatchUnlock</string>
-					<string>security.revealPasswords</string>
+					<string>security.authenticatedUnlock.requireAccountPasswordAfter</string>
+					<string>security.autolock.minutes</string>
 					<string>security.autolock.onDeviceLock</string>
 					<string>security.autolock.onWindowClose</string>
-					<string>security.autolock.minutes</string>
+					<string>security.blockSleepEnabled</string>
 					<string>security.clipboard.clearAfter</string>
 					<string>security.deviceClipboardSharing</string>
+					<string>security.revealPasswords</string>
+					<string>security.revealWifiQrCodes</string>
 				</array>
 				<key>Updates</key>
 				<array>
@@ -141,6 +158,148 @@
 					<string>updates.updateChannel</string>
 				</array>
 			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string>Force 1Password 8 to start at login</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>app.startAtLogin</string>
+			<key>pfm_title</key>
+			<string>Start at Login</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.checkCompromisedWebsites</string>
+			<key>pfm_title</key>
+			<string>Check for compromised websites</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.checkMfa</string>
+			<key>pfm_title</key>
+			<string>Check for two-factor authentication</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>privacy.checkPasskeys</string>
+			<key>pfm_title</key>
+			<string>Check for passkeys</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string>Prevents device from sleeping while 1Password is active</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.blockSleepEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow 1Password to prevent your device from sleeping</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.revealWifiQrCodes</string>
+			<key>pfm_title</key>
+			<string>Always show Wi-Fi QR codes</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>browsers.other-trusted-apps.enabled</string>
+			<key>pfm_title</key>
+			<string>Allow connecting to a custom browser</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string>You can fill your usernames and passwords everywhere you need to sign in on your Mac</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.autofill.autosubmit</string>
+			<key>pfm_title</key>
+			<string>Submit automatically with Universal Autofill</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>8.0</string>
+			<key>pfm_description</key>
+			<string></string>
+			<key>pfm_note</key>
+			<string>The allowed values are one-day, two-weeks, thirty-days, and never</string>
+			<key>pfm_documentation_url</key>
+			<string>https://support.1password.com/mobile-device-management/</string>
+			<key>pfm_name</key>
+			<string>security.authenticatedUnlock.requireAccountPasswordAfter</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>one-day</string>
+				<string>thirty-days</string>
+				<string>two-weeks</string>
+				<string>never</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>1 Day</string>
+				<string>30 Days</string>
+				<string>2 Weeks</string>
+				<string>Never</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Set the password requirement timeframe</string>
 			<key>pfm_type</key>
 			<string>string</string>
 		</dict>
@@ -338,6 +497,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -244,8 +244,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_note</key>
-			<string>The allowed values are one-day, two-weeks, thirty-days, and never</string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-12-19T22:03:37Z</date>
+	<date>2024-12-20T13:41:48Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -111,7 +111,6 @@
 			<string>PFC_SegmentedControl_0</string>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>Browser</string>
 				<string>General</string>
 				<string>Privacy</string>
 				<string>Security</string>
@@ -121,13 +120,10 @@
 			<string>always</string>
 			<key>pfm_segments</key>
 			<dict>
-				<key>Browser</key>
-				<array>
-					<string>browsers.other-trusted-apps.enabled</string>
-				</array>
 				<key>General</key>
 				<array>
 					<string>app.startAtLogin</string>
+					<string>browsers.other-trusted-apps.enabled</string>
 					<string>security.autofill.autosubmit</string>
 				</array>
 				<key>Privacy</key>
@@ -162,8 +158,6 @@
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Force 1Password 8 to start at login</string>
 			<key>pfm_documentation_url</key>
@@ -176,10 +170,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -190,10 +180,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -204,10 +190,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -218,8 +200,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Prevents device from sleeping while 1Password is active</string>
 			<key>pfm_documentation_url</key>
@@ -232,10 +212,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -246,10 +222,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_documentation_url</key>
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
@@ -260,8 +232,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>You can fill your usernames and passwords everywhere you need to sign in on your Mac</string>
 			<key>pfm_documentation_url</key>
@@ -274,10 +244,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
-			<key>pfm_description</key>
-			<string></string>
 			<key>pfm_note</key>
 			<string>The allowed values are one-day, two-weeks, thirty-days, and never</string>
 			<key>pfm_documentation_url</key>
@@ -304,8 +270,6 @@
 			<string>string</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>If present enforces whether biometric unlock is allowed (Preferences &gt; Security &gt; Unlock).</string>
 			<key>pfm_documentation_url</key>
@@ -318,8 +282,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>If present enforces whether Apple Watch unlock is allowed (Preferences &gt; Security &gt; Unlock).</string>
 			<key>pfm_name</key>
@@ -330,8 +292,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces showing passwords and full credit card numbers (Preferences &gt; Security &gt; Conceal Fields).</string>
 			<key>pfm_documentation_url</key>
@@ -344,8 +304,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces the configured locked on sleep,screensaver, or switching users (Preferences &gt; Security &gt; Auto-lock).</string>
 			<key>pfm_documentation_url</key>
@@ -358,8 +316,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces the configured lock on app exit preference</string>
 			<key>pfm_documentation_url</key>
@@ -372,8 +328,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces the lock on idle time preference (Preferences &gt; Security &gt; Lock).</string>
 			<key>pfm_documentation_url</key>
@@ -394,8 +348,6 @@
 			<string>minutes</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>The amount of time after copying a 1Password item that it is cleared from the clipboard (Preferences &gt; Security &gt; Clipboard).</string>
 			<key>pfm_documentation_url</key>
@@ -408,8 +360,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Enforces whether the clear clipboard preference is enabled or disabled (Preferences &gt; Security &gt; Clear clipboard contents).</string>
 			<key>pfm_documentation_url</key>
@@ -422,8 +372,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Show app and website icons</string>
 			<key>pfm_documentation_url</key>
@@ -436,8 +384,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Check for vulnerable passwords</string>
 			<key>pfm_documentation_url</key>
@@ -450,8 +396,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Automatically check for updates</string>
 			<key>pfm_documentation_url</key>
@@ -464,8 +408,6 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
-			<string>8.0</string>
 			<key>pfm_description</key>
 			<string>Set release channel</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
+++ b/Manifests/ManagedPreferencesApplications/com.1password.1password.plist
@@ -380,6 +380,8 @@
 			<string>https://support.1password.com/mobile-device-management/</string>
 			<key>pfm_name</key>
 			<string>security.autolock.minutes</string>
+			<key>pfm_note</key>
+			<string>You can enforce 1Password auto lock now via 1Password.com as an authenication policy: https://support.1password.com/auto-lock-policy/#manage-the-policy</string>
 			<key>pfm_range_max</key>
 			<integer>1440</integer>
 			<key>pfm_range_min</key>


### PR DESCRIPTION
Added the following new preferences keys to 1Password 8 manifest. 

[Documentation](https://support.1password.com/mobile-device-management/)

- browsers.other-trusted-apps.enabled
- app.startAtLogin
- security.autofill.autosubmit
- privacy.checkCompromisedWebsites
- privacy.checkMfa
- privacy.checkPasskeys
- security.authenticatedUnlock.requireAccountPasswordAfter
- security.blockSleepEnabled
- security.revealPasswords
- security.revealWifiQrCodes

Addressed https://github.com/ProfileManifests/ProfileManifests/issues/727 - https://github.com/ProfileManifests/ProfileManifests/pull/736/commits/e2496100794be682307a9a5d09feb72ba969c8c8

Tested against ProfileCreator 0.3.3.