### PR TITLE
[com.apple.siri] Add VoiceTriggerUserEnabled

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.Siri.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Siri.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2018-07-18T08:58:48Z</date>
+	<date>2024-12-30T21:13:21Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -128,6 +128,20 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Ensure Siri &quot;Listen For&quot; is disabled</string>
+			<key>pfm_macos_min</key>
+			<string>14.0</string>
+			<key>pfm_name</key>
+			<string>VoiceTriggerUserEnabled</string>
+			<key>pfm_title</key>
+			<string>Disable Voice Trigger</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -139,6 +153,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses https://github.com/ProfileManifests/ProfileManifests/issues/730

[Documentation](https://github.com/usnistgov/macos_security/blob/sonoma/rules/system_settings/system_settings_siri_listen_disable.yaml)

Added preference key `VoiceTriggerUserEnabled` to `com.apple.siri` manifest. 

Tested on ProfileCreator 0.3.7