### PR TITLE
[com.apple.Safari.SandboxBroker] Add AlwaysPromptForDownloadFolder

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -144,7 +144,7 @@
 			<key>pfm_app_min</key>
 			<string>10.15</string>
 			<key>pfm_description</key>
-			<string>If enabled, sets &apos;File download location&apos; to &apos;Ask for each download&apos; (Settings &gt; General).</string>
+			<string>If enabled, sets 'File download location' to 'Ask for each download' (Settings &gt; General).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://derflounder.wordpress.com/2024/10/17/setting-safari-to-always-prompt-for-download-location-on-macos-sequoia/</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-01-06T19:50:20Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.14</string>
 	<key>pfm_platforms</key>
@@ -140,6 +140,20 @@
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>10.15</string>
+			<key>pfm_description</key>
+			<string>If enabled, sets &apos;File download location&apos; to &apos;Ask for each download&apos; (Settings &gt; General).</string>
+			<key>pfm_documentation_url</key>
+			<string>https://derflounder.wordpress.com/2024/10/17/setting-safari-to-always-prompt-for-download-location-on-macos-sequoia/</string>
+			<key>pfm_name</key>
+			<string>AlwaysPromptForDownloadFolder</string>
+			<key>pfm_title</key>
+			<string>Always Prompt For Download Folder</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -150,6 +164,6 @@
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>2</integer>
+	<integer>3</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -141,7 +141,7 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_app_min</key>
+			<key>pfm_macos_min</key>
 			<string>15.0</string>
 			<key>pfm_description</key>
 			<string>If enabled, sets 'File download location' to 'Ask for each download' (Settings &gt; General).</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -141,12 +141,12 @@
 			<string>boolean</string>
 		</dict>
 		<dict>
-			<key>pfm_macos_min</key>
-			<string>15.0</string>
 			<key>pfm_description</key>
 			<string>If enabled, sets 'File download location' to 'Ask for each download' (Settings &gt; General).</string>
 			<key>pfm_documentation_url</key>
 			<string>https://derflounder.wordpress.com/2024/10/17/setting-safari-to-always-prompt-for-download-location-on-macos-sequoia/</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
 			<key>pfm_name</key>
 			<string>AlwaysPromptForDownloadFolder</string>
 			<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.Safari.SandboxBroker.plist
@@ -142,7 +142,7 @@
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>10.15</string>
+			<string>15.0</string>
 			<key>pfm_description</key>
 			<string>If enabled, sets 'File download location' to 'Ask for each download' (Settings &gt; General).</string>
 			<key>pfm_documentation_url</key>


### PR DESCRIPTION
Addresses: https://github.com/ProfileManifests/ProfileManifests/issues/714

[Documentation](https://derflounder.wordpress.com/2024/10/17/setting-safari-to-always-prompt-for-download-location-on-macos-sequoia/)

Added AlwaysPromptForDownloadFolder to `com.apple.Safari.SandboxBroker`. 

Testing: ProfileCreator and iMazing Profile Editor (profile applied fine on 15.2)