### PR TITLE
Supplement missing require tags in conditionals

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.finder.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.finder.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-01-15T11:02:30Z</date>
+	<date>2025-01-15T16:36:56Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -182,6 +182,8 @@
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -202,8 +204,6 @@
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
-					<key>pfm_require</key>
-					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApple/com.apple.finder.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.finder.plist
@@ -9,7 +9,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -202,6 +202,8 @@
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
+++ b/Manifests/ManagedPreferencesApplications/com.agilebits.onepassword7.plist
@@ -15,7 +15,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-02-01T10:06:10Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -333,6 +333,8 @@ To set the Master Password timeout to "Never", set the value to -1 (this will be
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -407,6 +409,8 @@ To set the Master Password timeout to "Never", set the value to -1 (this will be
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
+++ b/Manifests/ManagedPreferencesApplications/com.brave.Browser.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-12-18T15:25:37Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -8714,6 +8714,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 					<key>pfm_conditionals</key>
 					<array>
 						<dict>
+							<key>pfm_require</key>
+							<string>always</string>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
@@ -8753,6 +8755,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_conditionals</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
@@ -8799,6 +8803,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_conditionals</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-04T15:50:02Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -8697,6 +8697,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 					<key>pfm_conditionals</key>
 					<array>
 						<dict>
+							<key>pfm_require</key>
+							<string>always</string>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
@@ -8736,6 +8738,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_conditionals</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
@@ -8800,6 +8804,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>

--- a/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Chrome.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2025-01-15T11:02:30Z</date>
+	<date>2025-01-15T16:36:56Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -8786,6 +8786,8 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_conditionals</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>
@@ -8804,8 +8806,6 @@ If the page size is unavailable on the printer chosen by the user this policy is
 							<key>pfm_exclude</key>
 							<array>
 								<dict>
-									<key>pfm_require</key>
-									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>

--- a/Manifests/ManagedPreferencesApplications/com.google.santa.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.santa.plist
@@ -11,7 +11,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2022-08-11T00:20:00Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -723,6 +723,8 @@ For example: https://sync-server-hostname/%machine_id%/%file_sha%</string>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -773,6 +775,8 @@ For example: https://sync-server-hostname/%machine_id%/%file_sha%</string>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApplications/com.hjuutilainen.MunkiAdmin.plist
+++ b/Manifests/ManagedPreferencesApplications/com.hjuutilainen.MunkiAdmin.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13</string>
 	<key>pfm_platforms</key>
@@ -293,6 +293,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -339,6 +341,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -385,6 +389,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -479,6 +485,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -629,6 +637,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -673,6 +683,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -717,6 +729,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -771,6 +785,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -815,6 +831,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -859,6 +877,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -903,6 +923,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -947,6 +969,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -991,6 +1015,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1035,6 +1061,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1079,6 +1107,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1123,6 +1153,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1167,6 +1199,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1211,6 +1245,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1255,6 +1291,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1299,6 +1337,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1343,6 +1383,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1387,6 +1429,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1431,6 +1475,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1475,6 +1521,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1519,6 +1567,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1563,6 +1613,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1607,6 +1659,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1651,6 +1705,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1695,6 +1751,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1739,6 +1797,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1783,6 +1843,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1827,6 +1889,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1871,6 +1935,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1915,6 +1981,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1959,6 +2027,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2003,6 +2073,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2047,6 +2119,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2091,6 +2165,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2135,6 +2211,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2179,6 +2257,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -2223,6 +2303,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-01-10T12:42:17Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -391,6 +391,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -497,6 +499,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -821,6 +825,8 @@ A profile can consist of payloads with different version numbers. For example, c
 							<key>pfm_conditionals</key>
 							<array>
 								<dict>
+									<key>pfm_require</key>
+									<string>always</string>
 									<key>pfm_target_conditions</key>
 									<array>
 										<dict>

--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-01-15T11:02:30Z</date>
+	<date>2025-01-15T16:36:56Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -477,6 +477,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -499,8 +501,6 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
-					<key>pfm_require</key>
-					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
+++ b/Manifests/ManagedPreferencesApplications/nl.root3.support.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-07-29T11:57:57Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0.1</string>
 	<key>pfm_platforms</key>
@@ -744,6 +744,8 @@
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -838,6 +840,8 @@ Command: Zsh command or path to a script. Be aware that this will be executed as
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -932,6 +936,8 @@ Command: Zsh command or path to a script. Be aware that this will be executed as
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1028,6 +1034,8 @@ Command: Zsh command or path to a script. Be aware that this will be executed as
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1122,6 +1130,8 @@ Command: Zsh command or path to a script. Be aware that this will be executed as
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -1216,6 +1226,8 @@ Command: Zsh command or path to a script. Be aware that this will be executed as
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.AssetCache.managed.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2024-05-16T08:07:50Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.13.4</string>
 	<key>pfm_platforms</key>
@@ -168,6 +168,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -457,6 +459,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -525,6 +529,8 @@ Availability: Available in macOS 10.13.4 and later.</string>
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -685,7 +691,7 @@ Availability: Available in macOS 10.13.4 and later.</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<real>0.2</real>
+			<real>0.20000000000000001</real>
 			<key>pfm_description_reference</key>
 			<string>The percentage of attenuation added to the upload time. Clamped minimum is 0% attenuation. Values too large will exceed the ImportTimeout and cause failures.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
+++ b/Manifests/ManifestsApple/com.apple.dnsSettings.managed.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>14.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-12T10:00:38Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>11.0</string>
 	<key>pfm_platforms</key>
@@ -178,6 +178,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<key>pfm_conditionals</key>
 					<array>
 						<dict>
+							<key>pfm_require</key>
+							<string>always</string>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>
@@ -206,6 +208,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<key>pfm_conditionals</key>
 					<array>
 						<dict>
+							<key>pfm_require</key>
+							<string>always</string>
 							<key>pfm_target_conditions</key>
 							<array>
 								<dict>

--- a/Manifests/ManifestsApple/com.apple.extensiblesso.plist
+++ b/Manifests/ManifestsApple/com.apple.extensiblesso.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>13.0</string>
 	<key>pfm_last_modified</key>
-	<date>2025-01-15T11:02:30Z</date>
+	<date>2025-01-15T16:36:56Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -225,6 +225,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -248,8 +250,6 @@ Host names that begin with a “.” are wildcard suffixes that match all subdom
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
-					<key>pfm_require</key>
-					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>

--- a/Manifests/ManifestsApple/com.apple.extensiblesso.plist
+++ b/Manifests/ManifestsApple/com.apple.extensiblesso.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>13.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-09-12T09:07:25Z</date>
+	<date>2025-01-15T11:02:30Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.15</string>
 	<key>pfm_platforms</key>
@@ -248,6 +248,8 @@ Host names that begin with a “.” are wildcard suffixes that match all subdom
 			<key>pfm_exclude</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -341,6 +343,8 @@ Hosts that begin with a "." are wildcard suffixes and will match all subdomains,
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>
@@ -469,6 +473,8 @@ The system:
 			<key>pfm_conditionals</key>
 			<array>
 				<dict>
+					<key>pfm_require</key>
+					<string>always</string>
 					<key>pfm_target_conditions</key>
 					<array>
 						<dict>


### PR DESCRIPTION
Supplemented certain `pfm_conditionals` in the repository were the `pfm_require` tag was missing.