### PR TITLE
Minor OS update

### DIFF
--- a/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-iOS.plist
@@ -17,7 +17,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2024-12-13T08:49:11Z</date>
+	<date>2025-01-28T21:00:50Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>iOS</string>
@@ -163,6 +163,9 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>allowMailSummary</string>
 					<string>allowExternalIntelligenceIntegrations</string>
 					<string>allowExternalIntelligenceIntegrationsSignIn</string>
+					<string>allowedExternalIntelligenceWorkspaceIDs</string>
+					<string>allowNotesTranscriptionSummary</string>
+					<string>allowVisualIntelligenceSummary</string>
 				</array>
 				<key>AirDrop</key>
 				<array>
@@ -3190,6 +3193,63 @@ Possible values, with the US description of the rating level:
 			<string>boolean</string>
 		</dict>
 		<dict>
+			<key>pfm_description</key>
+			<string>Array of strings, but currently restricted to a single element. If present, Apple Intelligence will only allow the given external integration workspace ID to be used, and will require a sign-in in order to make requests; the user will be required to sign in to integrations that support signing in. Multiple payloads will combine using an intersect operation. This means the allowed set of workspace IDs can become the empty set if conflicting values are specified in multiple payloads.</string>
+			<key>pfm_ios_min</key>
+			<string>18.3</string>
+			<key>pfm_name</key>
+			<string>allowedExternalIntelligenceWorkspaceIDs</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>allowedWorkspaceID</string>
+					<key>pfm_repetition_max</key>
+					<integer>1</integer>
+					<key>pfm_title</key>
+					<string>Allowed Workspace ID</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Allowed External Intelligence Workspace IDs</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If false, disables transcription summarization in Notes.</string>
+			<key>pfm_ios_min</key>
+			<string>18.3</string>
+			<key>pfm_name</key>
+			<string>allowNotesTranscriptionSummary</string>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>When false, disables visual intelligence summarization.</string>
+			<key>pfm_ios_min</key>
+			<string>18.3</string>
+			<key>pfm_name</key>
+			<string>allowVisualIntelligenceSummary</string>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Allow Visual Intelligence Summary</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
@@ -3216,6 +3276,6 @@ Possible values, with the US description of the rating level:
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>16</integer>
+	<integer>17</integer>
 </dict>
 </plist>

--- a/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
+++ b/Manifests/ManifestsApple/com.apple.applicationaccess-macOS.plist
@@ -15,7 +15,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2024-12-13T08:12:27Z</date>
+	<date>2025-01-28T21:00:50Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>
@@ -156,6 +156,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>allowMailSummary</string>
 					<string>allowExternalIntelligenceIntegrations</string>
 					<string>allowExternalIntelligenceIntegrationsSignIn</string>
+					<string>allowedExternalIntelligenceWorkspaceIDs</string>
+					<string>allowNotesTranscriptionSummary</string>
 				</array>
 				<key>AirDrop</key>
 				<array>
@@ -1909,6 +1911,47 @@ The system still allows third-party password managers, and apps can use AutoFill
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Array of strings, but currently restricted to a single element. If present, Apple Intelligence will only allow the given external integration workspace ID to be used, and will require a sign-in in order to make requests; the user will be required to sign in to integrations that support signing in. Multiple payloads will combine using an intersect operation. This means the allowed set of workspace IDs can become the empty set if conflicting values are specified in multiple payloads.</string>
+			<key>pfm_macos_min</key>
+			<string>15.3</string>
+			<key>pfm_name</key>
+			<string>allowedExternalIntelligenceWorkspaceIDs</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_name</key>
+					<string>allowedWorkspaceID</string>
+					<key>pfm_repetition_max</key>
+					<integer>1</integer>
+					<key>pfm_title</key>
+					<string>Allowed Workspace ID</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_title</key>
+			<string>Allowed External Intelligence Workspace IDs</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>If false, disables transcription summarization in Notes.</string>
+			<key>pfm_macos_min</key>
+			<string>15.3</string>
+			<key>pfm_name</key>
+			<string>allowNotesTranscriptionSummary</string>
+			<key>pfm_supervised</key>
+			<true/>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>
@@ -1920,6 +1963,6 @@ The system still allows third-party password managers, and apps can use AutoFill
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>18</integer>
+	<integer>19</integer>
 </dict>
 </plist>


### PR DESCRIPTION
This PR includes new Restriction keys added to iOS 18.3 and macOS 15.3.

No new keys were added in any other manifest in these OS updates.