### PR TITLE
Tailscale: Add Preferences + Min Versions

### DIFF
--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -132,6 +132,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies the name of the organization managing Tailscale, for instance “XYZ Corp, Inc.”. The value will be displayed in the Tailscale client, so that users can easily reach your internal support resources.</string>
 			<key>pfm_documentation_url</key>
@@ -146,6 +148,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>XYZ Corp, Inc.</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a caption to be displayed in the Managed By view in the Tailscale client. Use this string value to provide your users with information on how to reach support resources for Tailscale in your organization.</string>
 			<key>pfm_documentation_url</key>
@@ -160,6 +164,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Support is available on the #tailscale channel on the company Slack.</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a URL pointing to a help desk webpage, or other helpful resources for users in the organization. Clicking the Support button in the Tailscale UI will open this webpage.</string>
 			<key>pfm_documentation_url</key>
@@ -174,6 +180,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://www.xyz-corp-example.com/helpdesk</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>The first time the application is opened on a Mac, Tailscale installs a macOS login helper. This allows Tailscale to start automatically when the user logs into their account. This boolean controls whether the login helper should start Tailscale at login time.</string>
 			<key>pfm_documentation_url</key>
@@ -186,6 +194,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>When set to true, this boolean instructs Tailscale to always be connected and actively monitor the tunnel state for disconnections. The Disconnect toggle will be disabled, to prevent users from disabling the VPN themselves. An attempt to disconnect will present a banner informing the user the organization’s policy prevents Tailscale from being disconnected. If the client detects the VPN tunnel is down because the Tailscale VPN process was terminated, Tailscale will automatically restart it and reconnect. You might want to use this policy together with an always-on VPN configuration profile.</string>
 			<key>pfm_documentation_url</key>
@@ -212,6 +222,8 @@ A profile can consist of payloads with different version numbers. For example, c
             <string>boolean</string>
         </dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>
 			<key>pfm_documentation_url</key>
@@ -226,6 +238,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>required:example.com</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.38.1</string>
 			<key>pfm_description</key>
 			<string>The LoginURL policy can be used to specify a custom control server URL. This should not be changed unless you are not using the standard Tailscale server. Use this policy if you’re deploying your own server, such as Headscale.</string>
 			<key>pfm_documentation_url</key>
@@ -424,6 +438,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -448,6 +464,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -472,6 +490,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -496,6 +516,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -520,6 +542,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -544,6 +568,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -594,6 +620,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
 			<key>pfm_documentation_url</key>
@@ -625,6 +653,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_description</key>
 			<string>When you use the Tailscale menu bar item to copy to the Clipboard the IP address of a device, a notification displaying the IP address is presented. Use this to suppress this Copied IP address to clipboard notification.</string>
 			<key>pfm_documentation_url</key>
@@ -663,6 +693,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
         </dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-02-22T08:00:00Z</date>
+	<date>2025-02-07T19:22:04Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -743,6 +743,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -674,6 +674,32 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.52</string>
+			<key>pfm_default</key>
+			<string>show</string>
+			<key>pfm_description</key>
+			<string>The VPNOnDemandSettings policy can be used to show or hide the VPN On Demand menu item. You might want to use this setting if you're deploying your own VPN configuration profile for Tailscale, and you don't want your users to interact with the on-demand VPN configuration you set up for them.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-vpn-on-demand-menu-item</string>
+			<key>pfm_name</key>
+			<string>VPNOnDemandSettings</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Hide the VPN On Demand menu item</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -381,7 +381,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>1.56</string>
+			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -606,6 +606,32 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+        <dict>
+			<key>pfm_app_min</key>
+			<string>1.68</string>
+            <key>pfm_default</key>
+            <string>hide</string>
+			<key>pfm_description</key>
+			<string>When set to hide, the user will not be able to install the CLI helper, and will instead be told to container their administrator.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-cli-integration-installer</string>
+			<key>pfm_name</key>
+			<string>CLIIntegration</string>
+			<key>pfm_title</key>
+			<string>Hide the CLI integration installer</string>
+            <key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_type</key>
+			<string>string</string>
+        </dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -197,6 +197,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+        <dict>
+            <key>pfm_app_min</key>
+            <string>1.68</string>
+            <key>pfm_description</key>
+            <string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
+            <key>pfm_documentation_url</key>
+            <string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
+            <key>pfm_name</key>
+            <string>HideDHCP121Warnings</string>
+            <key>pfm_title</key>
+            <string>Suppress DHCP Option 121 warnings</string>
+            <key>pfm_type</key>
+            <string>boolean</string>
+        </dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macos.plist
@@ -324,6 +324,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.80</string>
+			<key>pfm_description</key>
+			<string>The Hostname policy allows IT administrators to override the hostname configured in the operating system and reported to the coordination server. This can be particularly useful on mobile devices, where the hostname provided by the operating system usually only contains the device's manufacturer name and model.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#set-whether-device-hostnames-can-be-modified</string>
+			<key>pfm_name</key>
+			<string>Hostname</string>
+			<key>pfm_title</key>
+			<string>Set whether device hostnames can be modified</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>users-macbook-pro</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>1.56</string>
 			<key>pfm_default</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -750,6 +750,32 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.52</string>
+			<key>pfm_default</key>
+			<string>show</string>
+			<key>pfm_description</key>
+			<string>The VPNOnDemandSettings policy can be used to show or hide the VPN On Demand menu item. You might want to use this setting if you're deploying your own VPN configuration profile for Tailscale, and you don't want your users to interact with the on-demand VPN configuration you set up for them.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-vpn-on-demand-menu-item</string>
+			<key>pfm_name</key>
+			<string>VPNOnDemandSettings</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Hide the VPN On Demand menu item</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
 	</array>
 	<key>pfm_targets</key>
 	<array>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -682,6 +682,32 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+        <dict>
+			<key>pfm_app_min</key>
+			<string>1.68</string>
+            <key>pfm_default</key>
+            <string>hide</string>
+			<key>pfm_description</key>
+			<string>When set to hide, the user will not be able to install the CLI helper, and will instead be told to container their administrator.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#hide-the-cli-integration-installer</string>
+			<key>pfm_name</key>
+			<string>CLIIntegration</string>
+			<key>pfm_title</key>
+			<string>Hide the CLI integration installer</string>
+            <key>pfm_range_list</key>
+			<array>
+				<string>show</string>
+				<string>hide</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Show</string>
+				<string>Hide</string>
+			</array>
+			<key>pfm_type</key>
+			<string>string</string>
+        </dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-02-22T08:00:00Z</date>
+	<date>2025-02-07T19:22:04Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -825,6 +825,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<false/>
 	<key>pfm_version</key>
-	<integer>4</integer>
+	<integer>5</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -132,6 +132,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies the name of the organization managing Tailscale, for instance “XYZ Corp, Inc.”. The value will be displayed in the Tailscale client, so that users can easily reach your internal support resources.</string>
 			<key>pfm_documentation_url</key>
@@ -146,6 +148,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>XYZ Corp, Inc.</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a caption to be displayed in the Managed By view in the Tailscale client. Use this string value to provide your users with information on how to reach support resources for Tailscale in your organization.</string>
 			<key>pfm_documentation_url</key>
@@ -160,6 +164,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>Support is available on the #tailscale channel on the company Slack.</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specifies a URL pointing to a help desk webpage, or other helpful resources for users in the organization. Clicking the Support button in the Tailscale UI will open this webpage.</string>
 			<key>pfm_documentation_url</key>
@@ -174,6 +180,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>https://www.xyz-corp-example.com/helpdesk</string>
 		</dict>
 		<dict>
+			<key>pfm_app_min</key>
+			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>If you are using the Standalone version of Tailscale for macOS, the client will periodically check for updates automatically and notify the user that a new version is available, using the Sparkle framework. We recommend that you leave this feature on, in order to ensure your users receive any security updates in a timely manner. However, you might prefer to manually deploy updates and disable notifications of new available versions. Set this value to false to disable automatically checking for updates.</string>
 			<key>pfm_documentation_url</key>
@@ -186,6 +194,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>If you are using the Standalone version of Tailscale for macOS, the client can also install updates automatically. This feature also relies on the Sparkle framework. We recommend that you always turn this feature on, in order to ensure your users receive any security updates in a timely manner. However, if you manually manage updates, or prefer your users to be notified but to manually update, you can disable the automatic installation. When set to false, the standalone variant of Tailscale for macOS will require user input before updates are installed.</string>
 			<key>pfm_documentation_url</key>
@@ -198,6 +208,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -250,6 +262,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>The first time the application is opened on a Mac, Tailscale installs a macOS login helper. This allows Tailscale to start automatically when the user logs into their account. This boolean controls whether the login helper should start Tailscale at login time.</string>
 			<key>pfm_documentation_url</key>
@@ -262,6 +276,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>boolean</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>When set to true, this boolean instructs Tailscale to always be connected and actively monitor the tunnel state for disconnections. The Disconnect toggle will be disabled, to prevent users from disabling the VPN themselves. An attempt to disconnect will present a banner informing the user the organization’s policy prevents Tailscale from being disconnected. If the client detects the VPN tunnel is down because the Tailscale VPN process was terminated, Tailscale will automatically restart it and reconnect. You might want to use this policy together with an always-on VPN configuration profile.</string>
 			<key>pfm_documentation_url</key>
@@ -288,6 +304,8 @@ A profile can consist of payloads with different version numbers. For example, c
             <string>boolean</string>
         </dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>
 			<key>pfm_documentation_url</key>
@@ -302,6 +320,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>required:example.com</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.38.1</string>
 			<key>pfm_description</key>
 			<string>The LoginURL policy can be used to specify a custom control server URL. This should not be changed unless you are not using the standard Tailscale server. Use this policy if you’re deploying your own server, such as Headscale.</string>
 			<key>pfm_documentation_url</key>
@@ -500,6 +520,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -524,6 +546,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -548,6 +572,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -572,6 +598,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -596,6 +624,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -620,6 +650,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_default</key>
 			<string>show</string>
 			<key>pfm_description</key>
@@ -670,6 +702,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.52</string>
 			<key>pfm_description</key>
 			<string>Can be used to hide one or more categories of network devices normally displayed in the Tailscale client. Administrators can choose to hide: devices owned by the current user; devices owned by other users; tagged devices. If all three options are chosen, the "Network Devices" menu item disappears entirely and users aren’t able to see any device on the tailnet.</string>
 			<key>pfm_documentation_url</key>
@@ -701,6 +735,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>array</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.50</string>
 			<key>pfm_description</key>
 			<string>When you use the Tailscale menu bar item to copy to the Clipboard the IP address of a device, a notification displaying the IP address is presented. Use this to suppress this Copied IP address to clipboard notification.</string>
 			<key>pfm_documentation_url</key>
@@ -739,6 +775,8 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
         </dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.46</string>
 			<key>pfm_description</key>
 			<string>When you start Tailscale on your Mac for the first time, an onboarding flow is presented. It explains the Tailscale privacy policy, and guides the user in setting up the VPN configuration on their Mac. You might want to disable this onboarding flow if you are going to automatically set up the VPN configuration on the system by using a configuration profile. In order to do so, this boolean suppresses the onboarding flow when Tailscale launches for the first time and the value is set to true.</string>
 			<key>pfm_documentation_url</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -400,6 +400,22 @@ A profile can consist of payloads with different version numbers. For example, c
 			<string>string</string>
 		</dict>
 		<dict>
+            <key>pfm_app_min</key>
+			<string>1.80</string>
+			<key>pfm_description</key>
+			<string>The Hostname policy allows IT administrators to override the hostname configured in the operating system and reported to the coordination server. This can be particularly useful on mobile devices, where the hostname provided by the operating system usually only contains the device's manufacturer name and model.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://tailscale.com/kb/1315/mdm-keys#set-whether-device-hostnames-can-be-modified</string>
+			<key>pfm_name</key>
+			<string>Hostname</string>
+			<key>pfm_title</key>
+			<string>Set whether device hostnames can be modified</string>
+			<key>pfm_type</key>
+			<string>string</string>
+			<key>pfm_value_placeholder</key>
+			<string>users-macbook-pro</string>
+		</dict>
+		<dict>
 			<key>pfm_app_min</key>
 			<string>1.56</string>
 			<key>pfm_default</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -457,7 +457,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>1.56</string>
+			<string>1.52</string>
 			<key>pfm_default</key>
 			<string>user-decides</string>
 			<key>pfm_description</key>

--- a/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
+++ b/Manifests/ManagedPreferencesApplications/io.tailscale.ipn.macsys.plist
@@ -273,6 +273,20 @@ A profile can consist of payloads with different version numbers. For example, c
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
+        <dict>
+            <key>pfm_app_min</key>
+            <string>1.68</string>
+            <key>pfm_description</key>
+            <string>By default, Tailscale v1.68 and later detect when DHCP Option 121 is being used, and the client will display a warning to the user in the UI when usage of this option is detected. You may set the HideDHCP121Warnings system policy to true to hide such warnings if you have a legitimate need to use Option 121.</string>
+            <key>pfm_documentation_url</key>
+            <string>https://tailscale.com/kb/1315/mdm-keys#suppress-dhcp-option-121-warnings</string>
+            <key>pfm_name</key>
+            <string>HideDHCP121Warnings</string>
+            <key>pfm_title</key>
+            <string>Suppress DHCP Option 121 warnings</string>
+            <key>pfm_type</key>
+            <string>boolean</string>
+        </dict>
 		<dict>
 			<key>pfm_description</key>
 			<string>Specify a tailnet, and its identity provider will be used on the login page. If the policy value is prefixed with "required:"", Tailscale will force that identity provider to be used and won’t allow logging in with anything else.</string>


### PR DESCRIPTION
New Profiles for both `io.tailscale.ipn.macos.plist` &  `io.tailscale.ipn.macsys.plist`:
- **Add CLIIntegration to tailscale**
- **Add HideDHCP121Warnings to tailscale**
- **Add Hostname to tailscale**
- **Add VPNOnDemandSettings to tailscale**

Misc:
- **Add missing app_min values to tailscale**
- **fix incorrect minimum version in tailscale profile**
- **Bump modified+version**