### PR TITLE
Update com.github.macadmins.Nudge.plist

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
+++ b/Manifests/ManagedPreferencesApplications/com.github.macadmins.Nudge.plist
@@ -13,9 +13,9 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2024-08-12T12:17:30Z</date>
+	<date>2025-02-13T00:00:00Z</date>
 	<key>pfm_macos_min</key>
-	<string>11.0</string>
+	<string>12.0</string>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -1303,7 +1303,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<key>pfm_app_min</key>
 					<string>1.0</string>
 					<key>pfm_default</key>
-					<false/>
+					<true/>
 					<key>pfm_description</key>
 					<string>Enables an initial delay Nudge before launching the UI. This is useful if you do not want your users to all receive the Nudge prompt at the exact time of the LaunchAgent.</string>
 					<key>pfm_documentation_url</key>
@@ -1314,8 +1314,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>Random Delay</string>
 					<key>pfm_type</key>
 					<string>boolean</string>
-					<key>pfm_value_placeholder</key>
-					<string>true</string>
 				</dict>
 				<dict>
 					<key>pfm_default</key>


### PR DESCRIPTION
- Updated `pfm_macos_min` because the latest Nudge app has a macOS 12 requirement [source](https://github.com/macadmins/nudge/wiki/v2.0-features#breaking-changes)
- Changed `pfm_default` for `Random Delay` to `true` to match Nudge 2.0.2+ behavior [source](https://github.com/macadmins/nudge/releases/tag/v2.0.2.81720)
- Removed `pfm_value_placeholder` for `Random Delay` as it should no longer be needed.