### PR TITLE
Update Safari Manifest

### DIFF
--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -215,6 +215,9 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>BlockStoragePolicy</string>
 					<string>SendDoNotTrackHTTPHeader</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2PrivateBrowsingEnabled</string>
+					<string>WebKitPreferences.privateClickMeasurementEnabled</string>
+					<string>WebKitPreferences.storageBlockingPolicy</string>
+					<string>WebKitStorageBlockingPolicy</string>
 				</array>
 				<key>Security</key>
 				<array>
@@ -498,6 +501,52 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>Warn about Fraudulent Websites</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Manage advertising settings</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_Apple_macOS_13.0_Ventura_v3.0.0_L1.audit:9ba72640dddb6f0f8cccba555ef23517</string>
+			<key>pfm_name</key>
+			<string>WebKitPreferences.privateClickMeasurementEnabled</string>
+			<key>pfm_title</key>
+			<string>Advertising Privacy Protection</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Manage cross-site tracking and resistance from data brokers</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_Apple_macOS_12.0_Monterey_v4.0.0_L1.audit:a8c4cacd799fdac0038421f89b0d1c6e</string>
+			<key>pfm_name</key>
+			<string>WebKitPreferences.storageBlockingPolicy</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
+			<key>pfm_title</key>
+			<string>Prevent Cross-Site Tracking (WebKitPreferences)</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Manage cross-site tracking and resistance from data brokers</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_Apple_macOS_12.0_Monterey_v4.0.0_L1.audit:a8c4cacd799fdac0038421f89b0d1c6e</string>
+			<key>pfm_name</key>
+			<string>WebKitStorageBlockingPolicy</string>
+			<key>pfm_range_list</key>
+			<array>
+				<integer>1</integer>
+			</array>
+			<key>pfm_title</key>
+			<string>Prevent Cross-Site Tracking</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -495,7 +495,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_name</key>
 			<string>WarnAboutFraudulentWebsites</string>
 			<key>pfm_title</key>
-			<string>Warn about Fraudulent Website</string>
+			<string>Warn about Fraudulent Websites</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-02-20T05:12:09Z</date>
+	<date>2025-02-26T02:52:49Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -829,7 +829,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>Always</string>
 				<string>Never</string>
 				<string>Third Parties except sites you visited</string>
-				<string>Thrid Parties</string>
+				<string>Third Parties</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Block cookies and other website data</string>

--- a/Manifests/ManagedPreferencesApple/com.apple.safari.plist
+++ b/Manifests/ManagedPreferencesApple/com.apple.safari.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-02-20T05:12:09Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -157,6 +157,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>DefaultDatabaseQuota</string>
 					<string>IncludeDevelopMenu</string>
 					<string>PrintHeadersAndFooters</string>
+					<string>ShowFullURLInSmartSearchField</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2DefaultFixedFontSize</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2FixedFontFamily</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2DefaultFontSize</string>
@@ -202,6 +203,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>NewWindowBehavior</string>
 					<string>NewTabBehavior</string>
 					<string>OpenNewTabsInFront</string>
+					<string>ShowOverlayStatusBar</string>
 					<string>TabCreationPolicy</string>
 				</array>
 				<key>Notifications</key>
@@ -217,6 +219,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<key>Security</key>
 				<array>
 					<string>AskBeforeSubmittingInsecureForms</string>
+					<string>WarnAboutFraudulentWebsites</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaEnabled</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptCanOpenWindowsAutomatically</string>
 					<string>com.apple.Safari.ContentPageGroupIdentifier.WebKit2JavaScriptEnabled</string>
@@ -445,6 +448,54 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>AutoOpenSafeDownloads</string>
 			<key>pfm_title</key>
 			<string>Open Safe Downloads Automatically</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Controls whether mousing over a link displays the full URL that the link will follow</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_MacOS_Safari_Benchmark_v2.0.0_L1.audit:c75b2abc30f5dce21100b31cc4d4d8a3</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
+			<key>pfm_name</key>
+			<string>ShowOverlayStatusBar</string>
+			<key>pfm_title</key>
+			<string>Show Status Bar</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Full URL Path is Shown in Search Bar</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_MacOS_Safari_Benchmark_v2.0.0_L1.audit:2e00db7777604dd2a0cb9b462f668da3</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
+			<key>pfm_name</key>
+			<string>ShowFullURLInSmartSearchField</string>
+			<key>pfm_title</key>
+			<string>Show Full Website Address</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Alert the user that the site they are visiting is known to be malicious</string>
+			<key>pfm_documentation_url</key>
+			<string>https://www.tenable.com/audits/items/CIS_MacOS_Safari_Benchmark_v2.0.0_L1.audit:37f26137d5f0bda38c403263dc1279dc</string>
+			<key>pfm_macos_min</key>
+			<string>15.0</string>
+			<key>pfm_name</key>
+			<string>WarnAboutFraudulentWebsites</string>
+			<key>pfm_title</key>
+			<string>Warn about Fraudulent Website</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -1001,6 +1052,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>10</integer>
+	<integer>11</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Addresses: https://github.com/ProfileManifests/ProfileManifests/issues/762

Added the following keys to Safari manifest

- ShowFullURLInSmartSearchField
- ShowOverlayStatusBar
- WarnAboutFraudulentWebsites
- WebKitPreferences.privateClickMeasurementEnabled
- WebKitPreferences.storageBlockingPolicy
- WebKitStorageBlockingPolicy

Tested in ProfileCreator 1.9.2