### PR TITLE
Firefox manifest correction

### DIFF
--- a/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
+++ b/Manifests/ManagedPreferencesApplications/org.mozilla.firefox.plist
@@ -20,7 +20,7 @@
 	<key>pfm_interaction</key>
 	<string>undefined</string>
 	<key>pfm_last_modified</key>
-	<date>2025-02-04T16:20:00Z</date>
+	<date>2025-04-29T17:40:13Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -222,6 +222,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>RequestedLocales</string>
 					<string>Preferences</string>
 					<string>SupportMenu</string>
+					<string>MicrosoftEntraSSO</string>
 				</array>
 				<key>Network</key>
 				<array>
@@ -5789,20 +5790,6 @@ UrlbarInterventions Don't offer Firefox specific suggestions in the URL bar. (Fi
 				</dict>
 				<dict>
 					<key>pfm_app_min</key>
-					<string>132.0.1</string>
-					<key>pfm_default</key>
-					<false/>
-					<key>pfm_description</key>
-					<string>If this policy is set to true, Firefox will use credentials stored in the Company Portal to sign in to Microsoft Entra accounts. Affects `network.http.microsoft-entra-sso.enabled`.</string>
-					<key>pfm_name</key>
-					<string>MicrosoftEntraSSO</string>
-					<key>pfm_title</key>
-					<string>Allow single sign-on for Microsoft Entra accounts on macOS</string>
-					<key>pfm_type</key>
-					<string>boolean</string>
-				</dict>
-				<dict>
-					<key>pfm_app_min</key>
 					<string>68</string>
 					<key>pfm_default</key>
 					<true/>
@@ -5994,6 +5981,20 @@ UrlbarInterventions Don't offer Firefox specific suggestions in the URL bar. (Fi
 			<string>Support Menu</string>
 			<key>pfm_type</key>
 			<string>dictionary</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>132.0.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>If this policy is set to true, Firefox will use credentials stored in the Company Portal to sign in to Microsoft Entra accounts. Affects `network.http.microsoft-entra-sso.enabled`.</string>
+			<key>pfm_name</key>
+			<string>MicrosoftEntraSSO</string>
+			<key>pfm_title</key>
+			<string>Allow single sign-on for Microsoft Entra accounts on macOS</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 	</array>
 	<key>pfm_supervised</key>


### PR DESCRIPTION
`MicrosoftEntraSSO` in the Firefox manifest moved from previous incorrect location to the root.