### PR TITLE
fix: Set connectOnStart to default false for `dev.firezone.firezone`

### DIFF
--- a/Manifests/ManagedPreferencesApplications/dev.firezone.firezone.plist
+++ b/Manifests/ManagedPreferencesApplications/dev.firezone.firezone.plist
@@ -185,7 +185,7 @@ A profile can consist of payloads with different version numbers. For example, c
 		</dict>
 		<dict>
 			<key>pfm_default</key>
-			<true/>
+			<false/>
 			<key>pfm_description</key>
 			<string>Try to connect to Firezone using the saved token and configuration when the client application starts. If the authentication token is expired, the client will start in a disconnected state.</string>
 			<key>pfm_name</key>


### PR DESCRIPTION
@relgit Apologies - one minor bug slipped in during prior to merging #791 . The default value in the client for this setting is actually `false`, so updating this to reflect that.