### PR TITLE
Chrome Update channel

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2023-08-15T08:00:00Z</date>
+	<date>2025-08-11T12:20:32Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -319,6 +319,36 @@ Updates never applied = Never update Chrome</string>
 							<key>pfm_value_unit</key>
 							<string>major version</string>
 						</dict>
+						<dict>
+							<key>pfm_default</key>
+							<string>Stable</string>
+							<key>pfm_description</key>
+							<string>Choose the Stable, Extended stable, Beta, or Dev Chrome browser update channel for Chrome version 90 or above.
+Google Software Update will not downgrade Chrome to a lower version when switching channels.
+Chrome continues to follow the last channel on which it received an update if the TargetChannel policy is cleared.</string>
+							<key>pfm_documentation_url</key>
+							<string>https://support.google.com/chrome/a/answer/7591084#zippy=%2Cset-chrome-browser-to-a-specific-release-channel</string>
+							<key>pfm_name</key>
+							<string>TargetChannel</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>stable</string>
+								<string>extended</string>
+								<string>beta</string>
+								<string>dev</string>
+							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>Stable</string>
+								<string>Extended Stable</string>
+								<string>Beta</string>
+								<string>Dev</string>
+							</array>
+							<key>pfm_title</key>
+							<string>Chrome Update Release Channel</string>
+							<key>pfm_type</key>
+							<string>string</string>
+						</dict>
 					</array>
 					<key>pfm_title</key>
 					<string>Chrome Update settings</string>
@@ -520,6 +550,6 @@ Updates never applied = Never update Backup &amp; Sync</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>1</integer>
+	<integer>2</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
+++ b/Manifests/ManagedPreferencesApplications/com.google.Keystone.plist
@@ -13,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2025-08-11T12:20:32Z</date>
+	<date>2025-08-11T15:50:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -321,7 +321,7 @@ Updates never applied = Never update Chrome</string>
 						</dict>
 						<dict>
 							<key>pfm_default</key>
-							<string>Stable</string>
+							<string>stable</string>
 							<key>pfm_description</key>
 							<string>Choose the Stable, Extended stable, Beta, or Dev Chrome browser update channel for Chrome version 90 or above.
 Google Software Update will not downgrade Chrome to a lower version when switching channels.


### PR DESCRIPTION
Added the option to select a Chrome update release channel in the Google Software Update manifest.