### PR TITLE
Relocate ServerPort key as a subkey to SyslogOptions

### DIFF
--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-06-04T14:30:53Z</date>
+	<date>2025-06-30T14:30:53Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -824,23 +824,9 @@ A profile can consist of payloads with different version numbers. For example, c
 					<key>pfm_app_min</key>
 					<string>1.5.0</string>
 					<key>pfm_default</key>
-					<integer>514</integer>
-					<key>pfm_description</key>
-					<string>The port of the logging server.</string>
-					<key>pfm_name</key>
-					<string>ServerPort</string>
-					<key>pfm_title</key>
-					<string>Server Port</string>
-					<key>pfm_type</key>
-					<string>integer</string>
-				</dict>
-				<dict>
-					<key>pfm_app_min</key>
-					<string>1.5.0</string>
-					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set to true, the log messages are sent via TCP instead of UDP. By default, messages are sent via UDP.</string>
+					<string>If set to true, the log messages are sent via TCP instead of UDP. By default, messages are sent via UDP. Deprecated as of v2.0</string>
 					<key>pfm_name</key>
 					<string>EnableTCP</string>
 					<key>pfm_title</key>
@@ -993,6 +979,20 @@ A profile can consist of payloads with different version numbers. For example, c
 							<key>pfm_app_min</key>
 							<string>1.5.0</string>
 							<key>pfm_default</key>
+							<integer>514</integer>
+							<key>pfm_description</key>
+							<string>The port of the logging server.</string>
+							<key>pfm_name</key>
+							<string>ServerPort</string>
+							<key>pfm_title</key>
+							<string>Server Port</string>
+							<key>pfm_type</key>
+							<string>integer</string>
+						</dict>
+						<dict>
+							<key>pfm_app_min</key>
+							<string>1.5.0</string>
+							<key>pfm_default</key>
 							<integer>480</integer>
 							<key>pfm_description</key>
 							<string>Specify the maximum size of the syslog message (header + event message). If the syslog message is larger than the specified maximum, the message will be truncated at the end.</string>
@@ -1029,6 +1029,6 @@ A profile can consist of payloads with different version numbers. For example, c
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
+++ b/Manifests/ManagedPreferencesApplications/corp.sap.privileges.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2025-06-30T14:30:53Z</date>
+	<date>2025-08-25T11:45:50Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.12</string>
 	<key>pfm_platforms</key>
@@ -821,12 +821,16 @@ A profile can consist of payloads with different version numbers. For example, c
 					<string>string</string>
 				</dict>
 				<dict>
+					<key>pfm_app_deprecated</key>
+					<string>2.0.0</string>
+					<key>pfm_app_max</key>
+					<string>1.5.4</string>
 					<key>pfm_app_min</key>
 					<string>1.5.0</string>
 					<key>pfm_default</key>
 					<false/>
 					<key>pfm_description</key>
-					<string>If set to true, the log messages are sent via TCP instead of UDP. By default, messages are sent via UDP. Deprecated as of v2.0</string>
+					<string>If set to true, the log messages are sent via TCP instead of UDP. By default, messages are sent via UDP.</string>
 					<key>pfm_name</key>
 					<string>EnableTCP</string>
 					<key>pfm_title</key>


### PR DESCRIPTION
This PR brings and builds upon @lhaeger's Privileges fix (#803).