### PR TITLE
Make moduleName not required again for Screensaver profiles

### DIFF
--- a/Manifests/ManifestsApple/com.apple.screensaver.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.plist
@@ -244,8 +244,6 @@ Availability: Available in macOS 10.11 and later.</string>
 			<string>moduleName</string>
 			<key>pfm_note</key>
 			<string>The property is officially documented as required, however user reports and testing on macOS 14.4.1 have confirmed it to be optional.</string>
-			<key>pfm_require</key>
-			<string>always</string>
 			<key>pfm_title</key>
 			<string>Screensaver Module Name</string>
 			<key>pfm_type</key>

--- a/Manifests/ManifestsApple/com.apple.screensaver.user.plist
+++ b/Manifests/ManifestsApple/com.apple.screensaver.user.plist
@@ -160,8 +160,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>moduleName</string>
 			<key>pfm_note</key>
 			<string>The property is officially documented as required, however user reports and testing on macOS 14.4.1 have confirmed it to be optional.</string>
-			<key>pfm_require</key>
-			<string>always</string>
 			<key>pfm_title</key>
 			<string>Screensaver Module Name</string>
 			<key>pfm_type</key>


### PR DESCRIPTION
Technically it can also be left empty which fallbacks to forcing the system default, but the `pfm_default` prevents that currently