### PR TITLE
Claude: Add additional MDM settings

### DIFF
--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -142,14 +142,17 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>3P - Workspace - Chat surface</string>
 				<string>3P - Workspace - Cowork surface</string>
 				<string>3P - Workspace - Workspace</string>
+				<string>3P - Connectors</string>
 				<string>3P - Connectors - Authentication</string>
 				<string>3P - Connectors - Extensions</string>
 				<string>3P - Connectors - MCP</string>
 				<string>3P - Telemetry and updates</string>
 				<string>3P - Telemetry and updates - Auto update</string>
 				<string>3P - Telemetry and updates - Configuration updates</string>
+				<string>3P - Telemetry and updates - OTLP</string>
 				<string>3P - Limits - Token limits</string>
 				<string>3P - Appearance</string>
+				<string>3P - Appearance - Feature discovery</string>
 			</array>
 			<key>pfm_require</key>
 			<string>always</string>
@@ -188,6 +191,10 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>disableBypassPermissionsMode</string>
 					<string>blockReadsOutsideWorkingDirectories</string>
 				</array>
+				<key>3P - Connectors</key>
+				<array>
+					<string>claudeAiImport</string>
+				</array>
 				<key>3P - Connectors - Authentication</key>
 				<array>
 					<string>microsoftAuthBroker</string>
@@ -218,6 +225,18 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>relaunchEnforcementHours</string>
 					<string>configRecheckIntervalMinutes</string>
 				</array>
+				<key>3P - Telemetry and updates - OTLP</key>
+				<array>
+					<string>otlpEndpoint</string>
+					<string>otlpProtocol</string>
+					<string>otlpHeaders</string>
+					<string>otlpAuthMode</string>
+					<string>otlpHeadersHelper</string>
+					<string>otlpResourceAttributes</string>
+					<string>otlpDesktopLogLevel</string>
+					<string>otlpContentCapture</string>
+					<string>otlpTracesEnabled</string>
+				</array>
 				<key>3P - Limits - Token limits</key>
 				<array>
 					<string>inferenceMaxTokensPerWindow</string>
@@ -230,6 +249,10 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>deploymentDisplaySubtitle</string>
 					<string>disableConfigDeprecationWarnings</string>
 					<string>banner</string>
+				</array>
+				<key>3P - Appearance - Feature discovery</key>
+				<array>
+					<string>disableFeatureDiscovery</string>
 				</array>
 			</dict>
 			<key>pfm_type</key>
@@ -423,6 +446,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		<dict>
 			<key>pfm_app_min</key>
 			<string>1.19367.0</string>
+			<key>pfm_default</key>
+			<string>auto</string>
 			<key>pfm_description</key>
 			<string>Set to “disabled” to force browser-based Microsoft 365 sign-in instead of the native Company Portal / Windows account broker. One of: auto, disabled. Defaults to auto.</string>
 			<key>pfm_name</key>
@@ -730,6 +755,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		<dict>
 			<key>pfm_app_min</key>
 			<string>1.25927.0</string>
+			<key>pfm_default</key>
+			<string>high</string>
 			<key>pfm_description</key>
 			<string>Sets the default effort level for Claude Code sessions in Claude Desktop.</string>
 			<key>pfm_name</key>
@@ -744,11 +771,11 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			</array>
 			<key>pfm_range_list_titles</key>
 			<array>
-				<string>the least reasoning, for short, scoped, latency-sensitive tasks that aren't intelligence-sensitive</string>
-				<string>reduces token usage for cost-sensitive work that can trade off some intelligence</string>
-				<string>balances token usage and intelligence</string>
-				<string>deeper reasoning at higher token spend</string>
-				<string>the deepest reasoning level</string>
+				<string>Low</string>
+				<string>Medium</string>
+				<string>High</string>
+				<string>Extra High</string>
+				<string>Max</string>
 			</array>
 			<key>pfm_title</key>
 			<string>Effort Level</string>
@@ -782,6 +809,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 							<string>/Users</string>
 						</dict>
 						<dict>
+							<key>pfm_default</key>
+							<false/>
 							<key>pfm_description</key>
 							<string>Shows as a folder chip on the new-task page and skips the trust prompt. Users can remove it.</string>
 							<key>pfm_name</key>
@@ -936,6 +965,8 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		<dict>
 			<key>pfm_app_min</key>
 			<string>1.40609.0</string>
+			<key>pfm_default</key>
+			<false/>
 			<key>pfm_description</key>
 			<string>Show the signed-in user's identity-provider identity in the sidebar and account menu, and emit it as the OpenTelemetry enduser.id resource attribute.</string>
 			<key>pfm_documentation_url</key>
@@ -1006,6 +1037,227 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>{"enabled": true, "text": "This is an example.", "backgroundColor": "#F5F5F5", "textColor": "#000000", "linkUrl": "https://www.google.com/"}</string>
 			<key>pfm_type</key>
 			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.21459.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Suppress unprompted feature-announcement UI: the post-update “What's new” nudge and new-feature tips. Users can still open release notes themselves. Defaults to false.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#feature-discovery</string>
+			<key>pfm_name</key>
+			<string>disableFeatureDiscovery</string>
+			<key>pfm_title</key>
+			<string>Hide feature announcements</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.25927.0</string>
+			<key>pfm_description</key>
+			<string>Lets users import Claude.ai chats and projects, plus earlier Claude sessions on this computer, when enabled is true. automatic3pImport is a separate switch.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#connectors</string>
+			<key>pfm_name</key>
+			<string>claudeAiImport</string>
+			<key>pfm_title</key>
+			<string>Claude.ai data import</string>
+			<key>pfm_value_placeholder</key>
+			<string>{"enabled": false, "exportEnabled": false, "bannerBehavior": "detect"}</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_description</key>
+			<string>Where OpenTelemetry logs and metrics are sent. Leave blank to disable.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpEndpoint</string>
+			<key>pfm_title</key>
+			<string>OpenTelemetry collector endpoint</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_default</key>
+			<string>http/protobuf</string>
+			<key>pfm_description</key>
+			<string>grpc or http/protobuf. One of: http/protobuf, http/json, grpc. Defaults to http/protobuf.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpProtocol</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>http/protobuf</string>
+				<string>http/json</string>
+				<string>grpc</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>http/protobuf</string>
+				<string>http/json</string>
+				<string>grpc</string>
+			</array>
+			<key>pfm_title</key>
+			<string>OpenTelemetry exporter protocol</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.40609.0</string>
+			<key>pfm_description</key>
+			<string>Static collector headers — routing and tenant headers only. No credentials here; use Collector authentication or the headers helper script for tokens.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpHeaders</string>
+			<key>pfm_title</key>
+			<string>OpenTelemetry exporter headers</string>
+			<key>pfm_value_placeholder</key>
+			<string>{"Name": "value"}</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.30096.1</string>
+			<key>pfm_description</key>
+			<string>inference-credential sends the user's inference bearer token to the collector as Authorization: Bearer. One of: none, inference-credential.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpAuthMode</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>none</string>
+				<string>inference-credential</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>None</string>
+				<string>Inference Credential</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Collector authentication</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.30096.1</string>
+			<key>pfm_description</key>
+			<string>Absolute path to an executable that prints a JSON object of collector headers. Merged over the static headers and Collector authentication; the helper wins.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpHeadersHelper</string>
+			<key>pfm_title</key>
+			<string>OpenTelemetry headers helper script</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.40609.0</string>
+			<key>pfm_description</key>
+			<string>Extra resource attributes to attach to every span/metric. A static enduser.id set here always wins over the runtime identity.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpResourceAttributes</string>
+			<key>pfm_title</key>
+			<string>OpenTelemetry resource attributes</string>
+			<key>pfm_value_placeholder</key>
+			<string>{"Name": "value"}</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.9255.0</string>
+			<key>pfm_default</key>
+			<string>error</string>
+			<key>pfm_description</key>
+			<string>Controls the Claude Desktop application's events, separate from Cowork and Code sessions. Defaults to error. One of: off, error, warn, info, debug. Defaults to error.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpDesktopLogLevel</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>off</string>
+				<string>error</string>
+				<string>warn</string>
+				<string>info</string>
+				<string>debug</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Off</string>
+				<string>Error</string>
+				<string>Warn</string>
+				<string>Info</string>
+				<string>Debug</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Desktop telemetry export level</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.15962.0</string>
+			<key>pfm_description</key>
+			<string>Content categories the desktop exporter sends unredacted to your collector. Leave empty to redact all content (default). One of: userPrompts, assistantResponses, toolDetails, toolContent, rawApiBodies.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpContentCapture</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Name of a content capture category to enable a class of raw content in OpenTelemetry events sent to your collector (this data never reaches Anthropic)</string>
+					<key>pfm_name</key>
+					<string>otlpContentCaptureItem</string>
+					<key>pfm_title</key>
+					<string>Content capture category</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>userPrompts</string>
+				</dict>
+			</array>
+			<key>pfm_title</key>
+			<string>Content capture categories</string>
+			<key>pfm_type</key>
+			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.22209.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Also export OpenTelemetry traces from Cowork tasks and Code sessions. Uses Claude Code's session tracing.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#otlp</string>
+			<key>pfm_name</key>
+			<string>otlpTracesEnabled</string>
+			<key>pfm_title</key>
+			<string>Export traces</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 	</array>
 	<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -142,8 +142,10 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>3P - Workspace - Chat surface</string>
 				<string>3P - Workspace - Cowork surface</string>
 				<string>3P - Workspace - Workspace</string>
+				<string>3P - Connectors - Authentication</string>
 				<string>3P - Connectors - Extensions</string>
 				<string>3P - Connectors - MCP</string>
+				<string>3P - Telemetry and updates</string>
 				<string>3P - Telemetry and updates - Auto update</string>
 				<string>3P - Telemetry and updates - Configuration updates</string>
 				<string>3P - Limits - Token limits</string>
@@ -186,6 +188,10 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>disableBypassPermissionsMode</string>
 					<string>blockReadsOutsideWorkingDirectories</string>
 				</array>
+				<key>3P - Connectors - Authentication</key>
+				<array>
+					<string>microsoftAuthBroker</string>
+				</array>
 				<key>3P - Connectors - Extensions</key>
 				<array>
 					<string>isDesktopExtensionSignatureRequired</string>
@@ -196,7 +202,14 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>mcpPersistentAlwaysAllowEnabled</string>
 					<string>mcpToolTimeoutSec</string>
 				</array>
-				<key>3P - Telemetry and updates  - Auto update</key>
+				<key>3P - Telemetry and updates</key>
+				<array>
+					<string>deploymentOrganizationUuid</string>
+					<string>disableEssentialTelemetry</string>
+					<string>disableNonessentialTelemetry</string>
+					<string>disableNonessentialServices</string>
+				</array>
+				<key>3P - Telemetry and updates - Auto update</key>
 				<array>
 					<string>updateViaUpdatesHost</string>
 				</array>
@@ -406,6 +419,28 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>Allow Cowork</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.19367.0</string>
+			<key>pfm_description</key>
+			<string>Set to “disabled” to force browser-based Microsoft 365 sign-in instead of the native Company Portal / Windows account broker. One of: auto, disabled. Defaults to auto.</string>
+			<key>pfm_name</key>
+			<string>microsoftAuthBroker</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>auto</string>
+				<string>disabled</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Auto</string>
+				<string>Disabled</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Microsoft 365 native sign-in broker</string>
+			<key>pfm_type</key>
+			<string>string</string>
 		</dict>
 		<dict>
 			<key>pfm_default</key>
@@ -637,6 +672,60 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>MCP tool call timeout</string>
 			<key>pfm_type</key>
 			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_description</key>
+			<string>A UUID you generate. Tags telemetry so Anthropic support can locate your fleet's events, and namespaces each user's local data. Not used for auth.</string>
+			<key>pfm_name</key>
+			<string>deploymentOrganizationUuid</string>
+			<key>pfm_title</key>
+			<string>Organization UUID</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Crash and performance reports to Anthropic. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>disableEssentialTelemetry</string>
+			<key>pfm_title</key>
+			<string>Block essential telemetry</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Product-usage analytics and diagnostic-report uploads. No message content. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>disableNonessentialTelemetry</string>
+			<key>pfm_title</key>
+			<string>Block nonessential telemetry</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Connector favicons and the artifact-preview and MCP Apps widget iframe origins. Artifacts will not render. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>disableNonessentialServices</string>
+			<key>pfm_title</key>
+			<string>Block nonessential services</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -133,6 +133,84 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>string</string>
 		</dict>
 		<dict>
+			<key>pfm_name</key>
+			<string>PFC_SegmentedControl_0</string>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>Enterprise policy options</string>
+				<string>3P - Workspace - Authentication</string>
+				<string>3P - Workspace - Chat surface</string>
+				<string>3P - Workspace - Code surface</string>
+				<string>3P - Workspace - Cowork surface</string>
+				<string>3P - Telemetry and updates - Auto update</string>
+				<string>3P - Telemetry and updates - Configuration updates</string>
+				<string>3P - Limits - Token limits</string>
+				<string>3P - Appearance</string>
+			</array>
+			<key>pfm_require</key>
+			<string>always</string>
+			<key>pfm_segments</key>
+			<dict>
+				<key>Enterprise policy options</key>
+				<array>
+					<string>allowedWorkspaceFolders</string>
+					<string>autoUpdaterEnforcementHours</string>
+					<string>disableAutoUpdates</string>
+					<string>effortLevel</string>
+					<string>forceLoginOrgUUID</string>
+					<string>isClaudeCodeForDesktopEnabled</string>
+					<string>isDesktopExtensionEnabled</string>
+					<string>isDesktopExtensionDirectoryEnabled</string>
+					<string>isLocalDevMcpEnabled</string>
+					<string>secureVmFeaturesEnabled</string>
+				</array>
+				<key>3P - Workspace - Authentication</key>
+				<array>
+					<string>disableDeploymentModeChooser</string>
+					<string>disableDeepLinkRegistration</string>
+				</array>
+				<key>3P - Workspace - Chat surface</key>
+				<array>
+					<string>chatTabEnabled</string>
+					<string>chatAdvancedFileAnalysisEnabled</string>
+				</array>
+				<key>3P - Workspace - Code surface</key>
+				<array>
+					<string>isClaudeCodeForDesktopEnabled</string>
+				</array>
+				<key>3P - Workspace - Cowork surface</key>
+				<array>
+					<string>coworkTabEnabled</string>
+				</array>
+				<key>3P - Telemetry and updates  - Auto update</key>
+				<array>
+					<string>disableAutoUpdates</string>
+					<string>autoUpdaterEnforcementHours</string>
+					<string>updateViaUpdatesHost</string>
+				</array>
+				<key>3P - Telemetry and updates - Configuration updates</key>
+				<array>
+					<string>relaunchEnforcementHours</string>
+					<string>configRecheckIntervalMinutes</string>
+				</array>
+				<key>3P - Limits - Token limits</key>
+				<array>
+					<string>inferenceMaxTokensPerWindow</string>
+					<string>inferenceTokenWindowHours</string>
+				</array>
+				<key>3P - Appearance</key>
+				<array>
+					<string>endUserAttribution</string>
+					<string>deploymentDisplayName</string>
+					<string>deploymentDisplaySubtitle</string>
+					<string>disableConfigDeprecationWarnings</string>
+					<string>banner</string>
+				</array>
+			</dict>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
 			<key>pfm_description</key>
 			<string>Require login to belong to a specific organization. Accepts a single UUID string, which also pre-selects that organization during login, or an array of UUIDs where any listed organization is accepted without pre-selection. Login fails if the authenticated account does not belong to a listed organization.</string>
 			<key>pfm_name</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -13,7 +13,7 @@
 	<key>pfm_format_version</key>
 	<integer>1</integer>
 	<key>pfm_last_modified</key>
-	<date>2026-07-08T08:16:06Z</date>
+	<date>2026-09-04T12:50:00Z</date>
 	<key>pfm_platforms</key>
 	<array>
 		<string>macOS</string>
@@ -189,6 +189,56 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
+			<string>1.26832.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Read the update feed from releases.claude.com so api.anthropic.com can stay blocked. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>updateViaUpdatesHost</string>
+			<key>pfm_title</key>
+			<string>Check for updates on releases.claude.com</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.46388.1</string>
+			<key>pfm_default</key>
+			<integer>24</integer>
+			<key>pfm_description</key>
+			<string>Hours a user may keep working on the old configuration after a managed-configuration change is detected. 0 = restart required at once. Blank = 24 hours. Defaults to 24. Range: 0-336.</string>
+			<key>pfm_name</key>
+			<string>relaunchEnforcementHours</string>
+			<key>pfm_range_max</key>
+			<integer>336</integer>
+			<key>pfm_range_min</key>
+			<integer>0</integer>
+			<key>pfm_title</key>
+			<string>Configuration relaunch window</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.46388.1</string>
+			<key>pfm_default</key>
+			<integer>10</integer>
+			<key>pfm_description</key>
+			<string>Minutes between the running app's checks for a changed managed configuration. Blank = 10 minutes. Defaults to 10. Range: 2-30.</string>
+			<key>pfm_name</key>
+			<string>configRecheckIntervalMinutes</string>
+			<key>pfm_range_max</key>
+			<integer>30</integer>
+			<key>pfm_range_min</key>
+			<integer>2</integer>
+			<key>pfm_title</key>
+			<string>Configuration re-check interval</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
 			<string>0.14.1</string>
 			<key>pfm_default</key>
 			<true/>
@@ -250,6 +300,20 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>secureVmFeaturesEnabled</string>
 			<key>pfm_title</key>
 			<string>Enable Secure VM Features</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.9659.0</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Enable Cowork. Claude works on longer tasks like research, analysis, and documents. Defaults to true.</string>
+			<key>pfm_name</key>
+			<string>coworkTabEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow Cowork</string>
 			<key>pfm_type</key>
 			<string>boolean</string>
 		</dict>
@@ -452,12 +516,336 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_type</key>
 			<string>array</string>
 		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.25927.0</string>
+			<key>pfm_description</key>
+			<string>Sets the default effort level for Claude Code sessions in Claude Desktop.</string>
+			<key>pfm_name</key>
+			<string>effortLevel</string>
+			<key>pfm_range_list</key>
+			<array>
+				<string>low</string>
+				<string>medium</string>
+				<string>high</string>
+				<string>xhigh</string>
+				<string>max</string>
+			</array>
+			<key>pfm_range_list_titles</key>
+			<array>
+				<string>the least reasoning, for short, scoped, latency-sensitive tasks that aren't intelligence-sensitive</string>
+				<string>reduces token usage for cost-sensitive work that can trade off some intelligence</string>
+				<string>balances token usage and intelligence</string>
+				<string>deeper reasoning at higher token spend</string>
+				<string>the deepest reasoning level</string>
+			</array>
+			<key>pfm_title</key>
+			<string>Effort Level</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_description</key>
+			<string>Folders where Claude may work. Applies to both Cowork and Code sessions. Leave unset for unrestricted access. Paths can reference ~ and these environment variables, expanded per user: %OneDrive%, %OneDriveCommercial%, %OneDriveConsumer%, %APPDATA%, %LOCALAPPDATA%, %USERNAME%, %XDG_DOCUMENTS_DIR%. The set is fixed; an entry that references any other %VAR%, or one that is unset on the device, is ignored.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#allowedworkspacefolders-details</string>
+			<key>pfm_name</key>
+			<string>allowedWorkspaceFolders</string>
+			<key>pfm_title</key>
+			<string>Allowed Workspace Folders</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Absolute folder path. May start with ~ or one of the listed %VAR% tokens, expanded per user. Subfolders are included.</string>
+					<key>pfm_name</key>
+					<string>path</string>
+					<key>pfm_title</key>
+					<string>Path</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_value_placeholder</key>
+					<string>/Users</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Shows as a folder chip on the new-task page and skips the trust prompt. Users can remove it.</string>
+					<key>pfm_name</key>
+					<string>isDefaultSelected</string>
+					<key>pfm_title</key>
+					<string>Select Default</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Read-only folders can be viewed and searched but not modified in Cowork. In Code, applies to file tools only; Bash and SSH do not yet enforce read-only. One of: rw, ro.</string>
+					<key>pfm_name</key>
+					<string>mode</string>
+					<key>pfm_title</key>
+					<string>Mode</string>
+					<key>pfm_type</key>
+					<string>string</string>
+					<key>pfm_range_list</key>
+					<array>
+						<string>rw</string>
+						<string>ro</string>
+					</array>
+					<key>pfm_range_list_titles</key>
+					<array>
+						<string>Read/write</string>
+						<string>Read only</string>
+					</array>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+			<key>pfm_value_placeholder</key>
+			<string>["/Users", "~"]</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.46388.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Remove the bypass permissions mode from Code sessions and Cowork tasks, so Claude always follows the permission policy. Off by default.</string>
+			<key>pfm_name</key>
+			<string>disableBypassPermissionsMode</string>
+			<key>pfm_title</key>
+			<string>Disable bypass permissions mode</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.46388.1</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Keep Claude from reading files outside a Code session's working directories. File tools refuse such reads; sandboxed shell commands lose the home directory.</string>
+			<key>pfm_name</key>
+			<string>blockReadsOutsideWorkingDirectories</string>
+			<key>pfm_title</key>
+			<string>Block reads outside working directories</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.3834.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Users see only this provider at the login screen. The option to sign in to Claude.ai is hidden. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>disableDeploymentModeChooser</string>
+			<key>pfm_title</key>
+			<string>Disable Claude.ai sign-in</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.6889.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Stop external apps and websites from opening Claude Desktop via claude:// links. Defaults to false.</string>
+			<key>pfm_name</key>
+			<string>disableDeepLinkRegistration</string>
+			<key>pfm_title</key>
+			<string>Disable claude:// deep-link handling</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>v1.13576.0</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Enable Chat. Quick questions and drafting.</string>
+			<key>pfm_name</key>
+			<string>chatTabEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow Chat</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.21459.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Allow Claude to run code in a local sandbox to analyze attached files it can't read natively — like Excel and PowerPoint. Off by default.</string>
+			<key>pfm_name</key>
+			<string>chatAdvancedFileAnalysisEnabled</string>
+			<key>pfm_title</key>
+			<string>Advanced file analysis</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_description</key>
+			<string>Per-user soft cap, counted client-side over the token cap window. Not a server-enforced quota. Requires inferenceTokenWindowHours to also be set — without a window length the cap is inert and no limit is enforced.</string>
+			<key>pfm_name</key>
+			<string>inferenceMaxTokensPerWindow</string>
+			<key>pfm_title</key>
+			<string>Max tokens per window</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>0.14.1</string>
+			<key>pfm_description</key>
+			<string>Tumbling window length for the token cap. Max 720 hours (30 days). Range: 1-720. Required when inferenceMaxTokensPerWindow is set — the cap only takes effect once both are configured.</string>
+			<key>pfm_name</key>
+			<string>inferenceTokenWindowHours</string>
+			<key>pfm_range_max</key>
+			<integer>720</integer>
+			<key>pfm_range_min</key>
+			<integer>1</integer>
+			<key>pfm_title</key>
+			<string>Token cap window</string>
+			<key>pfm_type</key>
+			<string>integer</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.40609.0</string>
+			<key>pfm_description</key>
+			<string>Show the signed-in user's identity-provider identity in the sidebar and account menu, and emit it as the OpenTelemetry enduser.id resource attribute.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#appearance</string>
+			<key>pfm_name</key>
+			<string>endUserAttribution</string>
+			<key>pfm_title</key>
+			<string>End-user attribution</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.25927.0</string>
+			<key>pfm_description</key>
+			<string>Overrides the provider label shown in the sidebar footer, user-menu header, and connection-error banner.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#appearance</string>
+			<key>pfm_name</key>
+			<string>deploymentDisplayName</string>
+			<key>pfm_title</key>
+			<string>Deployment display name</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.25927.0</string>
+			<key>pfm_description</key>
+			<string>Optional detail shown after the deployment display name in the account-menu header.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#appearance</string>
+			<key>pfm_name</key>
+			<string>deploymentDisplaySubtitle</string>
+			<key>pfm_title</key>
+			<string>Deployment display subtitle</string>
+			<key>pfm_type</key>
+			<string>string</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.40609.0</string>
+			<key>pfm_default</key>
+			<false/>
+			<key>pfm_description</key>
+			<string>Don't show users the in-app warning that this configuration uses a deprecated field. The final reminder in the 24 hours before the cut-off still appears.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#appearance</string>
+			<key>pfm_name</key>
+			<string>disableConfigDeprecationWarnings</string>
+			<key>pfm_title</key>
+			<string>Hide configuration deprecation warnings</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.7196.0</string>
+			<key>pfm_description</key>
+			<string>A persistent banner across the top of the app window after sign-in.</string>
+			<key>pfm_documentation_url</key>
+			<string>https://claude.com/docs/third-party/claude-desktop/configuration#banner-details</string>
+			<key>pfm_name</key>
+			<string>banner</string>
+			<key>pfm_title</key>
+			<string>Organization banner</string>
+			<key>pfm_subkeys</key>
+			<array>
+				<dict>
+					<key>pfm_description</key>
+					<string>Turns the banner on. When false or unset, the other banner fields are ignored.</string>
+					<key>pfm_name</key>
+					<string>enabled</string>
+					<key>pfm_title</key>
+					<string>Enabled</string>
+					<key>pfm_type</key>
+					<string>boolean</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Single line, truncated on overflow. Maximum 200 characters.</string>
+					<key>pfm_name</key>
+					<string>text</string>
+					<key>pfm_title</key>
+					<string>Text</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Six-digit hex (#RRGGBB). Applied exactly as configured; not theme-adapted.</string>
+					<key>pfm_name</key>
+					<string>backgroundColor</string>
+					<key>pfm_title</key>
+					<string>Background Color</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Six-digit hex (#RRGGBB). Applied exactly as configured; not theme-adapted.</string>
+					<key>pfm_name</key>
+					<string>textColor</string>
+					<key>pfm_title</key>
+					<string>Text Color</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+				<dict>
+					<key>pfm_description</key>
+					<string>Optional HTTPS URL. The banner text becomes a link when set.</string>
+					<key>pfm_name</key>
+					<string>linkUrl</string>
+					<key>pfm_title</key>
+					<string>Link URL</string>
+					<key>pfm_type</key>
+					<string>string</string>
+				</dict>
+			</array>
+			<key>pfm_type</key>
+			<string>dictionary</string>
+		</dict>
 	</array>
 	<key>pfm_title</key>
 	<string>Claude Desktop</string>
 	<key>pfm_unique</key>
 	<true/>
 	<key>pfm_version</key>
-	<integer>5</integer>
+	<integer>6</integer>
 </dict>
 </plist>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -791,61 +791,10 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>banner</string>
 			<key>pfm_title</key>
 			<string>Organization banner</string>
-			<key>pfm_subkeys</key>
-			<array>
-				<dict>
-					<key>pfm_description</key>
-					<string>Turns the banner on. When false or unset, the other banner fields are ignored.</string>
-					<key>pfm_name</key>
-					<string>enabled</string>
-					<key>pfm_title</key>
-					<string>Enabled</string>
-					<key>pfm_type</key>
-					<string>boolean</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Single line, truncated on overflow. Maximum 200 characters.</string>
-					<key>pfm_name</key>
-					<string>text</string>
-					<key>pfm_title</key>
-					<string>Text</string>
-					<key>pfm_type</key>
-					<string>string</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Six-digit hex (#RRGGBB). Applied exactly as configured; not theme-adapted.</string>
-					<key>pfm_name</key>
-					<string>backgroundColor</string>
-					<key>pfm_title</key>
-					<string>Background Color</string>
-					<key>pfm_type</key>
-					<string>string</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Six-digit hex (#RRGGBB). Applied exactly as configured; not theme-adapted.</string>
-					<key>pfm_name</key>
-					<string>textColor</string>
-					<key>pfm_title</key>
-					<string>Text Color</string>
-					<key>pfm_type</key>
-					<string>string</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Optional HTTPS URL. The banner text becomes a link when set.</string>
-					<key>pfm_name</key>
-					<string>linkUrl</string>
-					<key>pfm_title</key>
-					<string>Link URL</string>
-					<key>pfm_type</key>
-					<string>string</string>
-				</dict>
-			</array>
+			<key>pfm_value_placeholder</key>
+			<string>{"enabled": true, "text": "This is an example.", "backgroundColor": "#F5F5F5", "textColor": "#000000", "linkUrl": "https://www.google.com/"}</string>
 			<key>pfm_type</key>
-			<string>dictionary</string>
+			<string>string</string>
 		</dict>
 	</array>
 	<key>pfm_title</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -556,52 +556,59 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_subkeys</key>
 			<array>
 				<dict>
-					<key>pfm_description</key>
-					<string>Absolute folder path. May start with ~ or one of the listed %VAR% tokens, expanded per user. Subfolders are included.</string>
-					<key>pfm_name</key>
-					<string>path</string>
-					<key>pfm_title</key>
-					<string>Path</string>
-					<key>pfm_type</key>
-					<string>string</string>
-					<key>pfm_value_placeholder</key>
-					<string>/Users</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Shows as a folder chip on the new-task page and skips the trust prompt. Users can remove it.</string>
-					<key>pfm_name</key>
-					<string>isDefaultSelected</string>
-					<key>pfm_title</key>
-					<string>Select Default</string>
-					<key>pfm_type</key>
-					<string>boolean</string>
-				</dict>
-				<dict>
-					<key>pfm_description</key>
-					<string>Read-only folders can be viewed and searched but not modified in Cowork. In Code, applies to file tools only; Bash and SSH do not yet enforce read-only. One of: rw, ro.</string>
-					<key>pfm_name</key>
-					<string>mode</string>
-					<key>pfm_title</key>
-					<string>Mode</string>
-					<key>pfm_type</key>
-					<string>string</string>
-					<key>pfm_range_list</key>
+					<key>pfm_subkeys</key>
 					<array>
-						<string>rw</string>
-						<string>ro</string>
+						<dict>
+							<key>pfm_description</key>
+							<string>Absolute folder path. May start with ~ or one of the listed %VAR% tokens, expanded per user. Subfolders are included.</string>
+							<key>pfm_name</key>
+							<string>path</string>
+							<key>pfm_title</key>
+							<string>Path</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_value_placeholder</key>
+							<string>/Users</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Shows as a folder chip on the new-task page and skips the trust prompt. Users can remove it.</string>
+							<key>pfm_name</key>
+							<string>isDefaultSelected</string>
+							<key>pfm_title</key>
+							<string>Select Default</string>
+							<key>pfm_type</key>
+							<string>boolean</string>
+						</dict>
+						<dict>
+							<key>pfm_description</key>
+							<string>Read-only folders can be viewed and searched but not modified in Cowork. In Code, applies to file tools only; Bash and SSH do not yet enforce read-only. One of: rw, ro.</string>
+							<key>pfm_name</key>
+							<string>mode</string>
+							<key>pfm_title</key>
+							<string>Mode</string>
+							<key>pfm_type</key>
+							<string>string</string>
+							<key>pfm_range_list</key>
+							<array>
+								<string>rw</string>
+								<string>ro</string>
+							</array>
+							<key>pfm_range_list_titles</key>
+							<array>
+								<string>Read/write</string>
+								<string>Read only</string>
+							</array>
+						</dict>
 					</array>
-					<key>pfm_range_list_titles</key>
-					<array>
-						<string>Read/write</string>
-						<string>Read only</string>
-					</array>
+					<key>pfm_type</key>
+					<string>dictionary</string>
 				</dict>
 			</array>
 			<key>pfm_type</key>
-			<string>dictionary</string>
+			<string>array</string>
 			<key>pfm_value_placeholder</key>
-			<string>["/Users", "~"]</string>
+			<string>[{“path” : “/Users”, “isDefaultSelected” : false, “mode” : “rw”}, {“path” : “~”, “isDefaultSelected” : true, “mode” : “ro”}]</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
@@ -661,7 +668,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>
-			<string>v1.13576.0</string>
+			<string>1.13576.0</string>
 			<key>pfm_default</key>
 			<true/>
 			<key>pfm_description</key>
@@ -727,7 +734,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<key>pfm_title</key>
 			<string>End-user attribution</string>
 			<key>pfm_type</key>
-			<string>string</string>
+			<string>boolean</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -140,8 +140,9 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>Enterprise policy options</string>
 				<string>3P - Workspace - Authentication</string>
 				<string>3P - Workspace - Chat surface</string>
-				<string>3P - Workspace - Code surface</string>
 				<string>3P - Workspace - Cowork surface</string>
+				<string>3P - Workspace - Workspace</string>
+				<string>3P - Connectors - Extensions</string>
 				<string>3P - Connectors - MCP</string>
 				<string>3P - Telemetry and updates - Auto update</string>
 				<string>3P - Telemetry and updates - Configuration updates</string>
@@ -175,13 +176,19 @@ During a profile replacement, the system updates payloads with the same 'Payload
 					<string>chatTabEnabled</string>
 					<string>chatAdvancedFileAnalysisEnabled</string>
 				</array>
-				<key>3P - Workspace - Code surface</key>
-				<array>
-					<string>isClaudeCodeForDesktopEnabled</string>
-				</array>
 				<key>3P - Workspace - Cowork surface</key>
 				<array>
 					<string>coworkTabEnabled</string>
+				</array>
+				<key>3P - Workspace - Workspace</key>
+				<array>
+					<string>disabledBuiltinTools</string>
+					<string>disableBypassPermissionsMode</string>
+					<string>blockReadsOutsideWorkingDirectories</string>
+				</array>
+				<key>3P - Connectors - Extensions</key>
+				<array>
+					<string>isDesktopExtensionSignatureRequired</string>
 				</array>
 				<key>3P - Connectors - MCP</key>
 				<array>
@@ -191,8 +198,6 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				</array>
 				<key>3P - Telemetry and updates  - Auto update</key>
 				<array>
-					<string>disableAutoUpdates</string>
-					<string>autoUpdaterEnforcementHours</string>
 					<string>updateViaUpdatesHost</string>
 				</array>
 				<key>3P - Telemetry and updates - Configuration updates</key>

--- a/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
+++ b/Manifests/ManagedPreferencesApplications/com.anthropic.claudefordesktop.plist
@@ -142,6 +142,7 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<string>3P - Workspace - Chat surface</string>
 				<string>3P - Workspace - Code surface</string>
 				<string>3P - Workspace - Cowork surface</string>
+				<string>3P - Connectors - MCP</string>
 				<string>3P - Telemetry and updates - Auto update</string>
 				<string>3P - Telemetry and updates - Configuration updates</string>
 				<string>3P - Limits - Token limits</string>
@@ -181,6 +182,12 @@ During a profile replacement, the system updates payloads with the same 'Payload
 				<key>3P - Workspace - Cowork surface</key>
 				<array>
 					<string>coworkTabEnabled</string>
+				</array>
+				<key>3P - Connectors - MCP</key>
+				<array>
+					<string>managedMcpServers</string>
+					<string>mcpPersistentAlwaysAllowEnabled</string>
+					<string>mcpToolTimeoutSec</string>
 				</array>
 				<key>3P - Telemetry and updates  - Auto update</key>
 				<array>
@@ -593,6 +600,38 @@ During a profile replacement, the system updates payloads with the same 'Payload
 			<string>Managed MCP Servers</string>
 			<key>pfm_type</key>
 			<string>array</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.24012.9</string>
+			<key>pfm_default</key>
+			<true/>
+			<key>pfm_description</key>
+			<string>Offer the persistent “Always allow” approval options for MCP tools. Disable to keep tool approvals per-call or session-scoped only. Defaults to true.</string>
+			<key>pfm_name</key>
+			<string>mcpPersistentAlwaysAllowEnabled</string>
+			<key>pfm_title</key>
+			<string>Allow persistent tool approvals</string>
+			<key>pfm_type</key>
+			<string>boolean</string>
+		</dict>
+		<dict>
+			<key>pfm_app_min</key>
+			<string>1.37937.0</string>
+			<key>pfm_default</key>
+			<integer>180</integer>
+			<key>pfm_description</key>
+			<string>Per-call timeout for MCP tool calls, in seconds. Default 180 (3 minutes). Range: 60-3600.</string>
+			<key>pfm_name</key>
+			<string>mcpToolTimeoutSec</string>
+			<key>pfm_range_max</key>
+			<integer>3600</integer>
+			<key>pfm_range_min</key>
+			<integer>60</integer>
+			<key>pfm_title</key>
+			<string>MCP tool call timeout</string>
+			<key>pfm_type</key>
+			<string>integer</string>
 		</dict>
 		<dict>
 			<key>pfm_app_min</key>


### PR DESCRIPTION
Note that Claude's documented MDM settings seem to be split across https://support.claude.com/en/articles/12622667-enterprise-configuration-for-claude-desktop#h_003283c7cb and https://claude.com/docs/third-party/claude-desktop/configuration for some reason, with the latter having a far more exhaustive and detailed list of available settings.

I didn't add all the Claude MDM settings currently available since that would have taken quite awhile, but I did add several. I would appreciate if someone could please double check the dictionary and array settings I added (specifically "allowedWorkspaceFolders" and "banner"), since while I checked other manifest examples I still wasn't 100% sure about the exact syntax format.