### PR TITLE
Documentation links supplement

### DIFF
--- a/Manifests/ManifestsApple/Configuration.plist
+++ b/Manifests/ManifestsApple/Configuration.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>pfm_description</key>
 	<string>Use this section to define general settings</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/toplevel</string>
 	<key>pfm_domain</key>
 	<string>Configuration</string>
 	<key>pfm_format_version</key>
@@ -13,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.dashboard.plist
+++ b/Manifests/ManifestsApple/com.apple.dashboard.plist
@@ -7,6 +7,8 @@
 	<key>pfm_description_reference</key>
 	<string>The Parental Control Dashboard payload is designated by specifying com.apple.dashboard as the PayloadType value.
 It is used to define a white list of dashboard widgets.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://github.com/apple/device-management/blob/release/mdm/profiles/com.apple.dashboard.yaml</string>
 	<key>pfm_domain</key>
 	<string>com.apple.dashboard</string>
 	<key>pfm_format_version</key>
@@ -14,7 +16,7 @@ It is used to define a white list of dashboard widgets.</string>
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>10.15</string>
 	<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.ironwood.support.plist
+++ b/Manifests/ManifestsApple/com.apple.ironwood.support.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>pfm_description</key>
 	<string>The payload that configures parental control for dictation and profanity.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://github.com/apple/device-management/blob/release/mdm/profiles/com.apple.ironwood.support.yaml</string>
 	<key>pfm_domain</key>
 	<string>com.apple.ironwood.support</string>
 	<key>pfm_format_version</key>
@@ -11,7 +13,7 @@
 	<key>pfm_interaction</key>
 	<string>combined</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>10.13</string>
 	<key>pfm_macos_min</key>

--- a/Manifests/ManifestsApple/com.apple.security.FDERecoveryRedirect.plist
+++ b/Manifests/ManifestsApple/com.apple.security.FDERecoveryRedirect.plist
@@ -10,6 +10,8 @@
 Note these cautions:
 • The payload must exist in a system-scoped profile.
 • Installing more than one payload of this type per machine will cause an error.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://github.com/apple/device-management/blob/release/mdm/profiles/com.apple.security.FDERecoveryRedirect.yaml</string>
 	<key>pfm_domain</key>
 	<string>com.apple.security.FDERecoveryRedirect</string>
 	<key>pfm_format_version</key>
@@ -17,7 +19,7 @@ Note these cautions:
 	<key>pfm_interaction</key>
 	<string>exclusive</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_deprecated</key>
 	<string>10.13</string>
 	<key>pfm_macos_max</key>

--- a/Manifests/ManifestsApple/com.apple.security.pem.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pem.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>pfm_description</key>
 	<string>The payload that configures a PEM-formatted certificate.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/certificatepem</string>
 	<key>pfm_domain</key>
 	<string>com.apple.security.pem</string>
 	<key>pfm_format_version</key>
@@ -13,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.pkcs1.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pkcs1.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>pfm_description</key>
 	<string>The payload that configures a PKCS #1-formatted certificate.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/certificatepkcs1</string>
 	<key>pfm_domain</key>
 	<string>com.apple.security.pkcs1</string>
 	<key>pfm_format_version</key>
@@ -13,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_platforms</key>

--- a/Manifests/ManifestsApple/com.apple.security.pkcs12.plist
+++ b/Manifests/ManifestsApple/com.apple.security.pkcs12.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>pfm_description</key>
 	<string>The payload that configures a PKCS #12-formatted certificate.</string>
+	<key>pfm_documentation_url</key>
+	<string>https://developer.apple.com/documentation/devicemanagement/certificatepkcs12</string>
 	<key>pfm_domain</key>
 	<string>com.apple.security.pkcs12</string>
 	<key>pfm_format_version</key>
@@ -13,7 +15,7 @@
 	<key>pfm_ios_min</key>
 	<string>4.0</string>
 	<key>pfm_last_modified</key>
-	<date>2026-08-24T08:00:30Z</date>
+	<date>2026-09-07T18:47:33Z</date>
 	<key>pfm_macos_min</key>
 	<string>10.7</string>
 	<key>pfm_note</key>


### PR DESCRIPTION
Documentation links added to a handful of system manifests.

In cases where no Apple developer website links were available, links to Apple's Device Management repository were used instead.